### PR TITLE
Fix errors related to use of deprecated API

### DIFF
--- a/Assets/Examples/Demo.cs
+++ b/Assets/Examples/Demo.cs
@@ -123,7 +123,7 @@ public class Demo : MonoBehaviour
 		this.m_textures [2].Apply ();
         		
 		//display on plane
-		renderer.material.mainTexture = this.m_textures [0];
+		GetComponent<Renderer>().material.mainTexture = this.m_textures [0];
             
 
 		//write images to disk

--- a/Assets/Tutorials/Tutorial3.cs
+++ b/Assets/Tutorials/Tutorial3.cs
@@ -32,7 +32,7 @@ public class Tutorial3 : MonoBehaviour
 
 		// Set it. It may appear inverted from the example on the LibNoise site depending 
 		// on the angle at which the object is rotated/viewed.
-		renderer.material.mainTexture = image;
+		GetComponent<Renderer>().material.mainTexture = image;
 
 		// We don't do the light changes for the texture, since that's beyond the scope of 
 		// this port

--- a/Assets/Tutorials/Tutorial4.cs
+++ b/Assets/Tutorials/Tutorial4.cs
@@ -41,7 +41,7 @@ public class Tutorial4 : MonoBehaviour
 
 		// Set it. It may appear inverted from the example on the LibNoise site depending 
 		// on the angle at which the object is rotated/viewed.
-		renderer.material.mainTexture = image;
+		GetComponent<Renderer>().material.mainTexture = image;
 
 		// We don't do the light changes for the texture, since that's beyond the scope of 
 		// this port

--- a/Assets/Tutorials/Tutorial5.cs
+++ b/Assets/Tutorials/Tutorial5.cs
@@ -63,7 +63,7 @@ public class Tutorial5 : MonoBehaviour
 		var heightMapBuilder = new Noise2D(256, 256, generator);
 		heightMapBuilder.GeneratePlanar(_left, _right, _top, _bottom);
 		var image = heightMapBuilder.GetTexture(_gradient);
-		renderer.material.mainTexture = image;
+		GetComponent<Renderer>().material.mainTexture = image;
 	}
 	
 }

--- a/Assets/Tutorials/Tutorial6.cs
+++ b/Assets/Tutorials/Tutorial6.cs
@@ -53,7 +53,7 @@ public class Tutorial6 : MonoBehaviour
 		var heightMapBuilder = new Noise2D(256, 256, generator);
 		heightMapBuilder.GeneratePlanar(_left, _right, _top, _bottom);
 		var image = heightMapBuilder.GetTexture(_gradient);
-		renderer.material.mainTexture = image;
+		GetComponent<Renderer>().material.mainTexture = image;
 	}
 	
 }

--- a/Assets/Tutorials/Tutorial7.cs
+++ b/Assets/Tutorials/Tutorial7.cs
@@ -64,7 +64,7 @@ public class Tutorial7 : MonoBehaviour
 		var heightMapBuilder = new Noise2D(513, 513, generator);
 		heightMapBuilder.GeneratePlanar(_left, _right, _top, _bottom);
 		var image = heightMapBuilder.GetTexture(_gradient);
-		renderer.material.mainTexture = image;
+		GetComponent<Renderer>().material.mainTexture = image;
 	}
 	
 }

--- a/Assets/Tutorials/Tutorial8.cs
+++ b/Assets/Tutorials/Tutorial8.cs
@@ -23,7 +23,7 @@ public class Tutorial8 : MonoBehaviour
 		heightMapBuilder.GenerateSpherical(_north, _south, _west, _east);
 
 		var image = heightMapBuilder.GetTexture(_gradient);
-		renderer.material.mainTexture = image;
+		GetComponent<Renderer>().material.mainTexture = image;
 
 
 


### PR DESCRIPTION
Replaces uses of the `renderer` property with `GetComponent<Renderer>()`. The former is deprecated in current versions of Unity and will cause errors on startup.

This should resolve issues #2 and #3.